### PR TITLE
Rename `rev_color` to `rev_col` to prevent possible UnboundLocalError

### DIFF
--- a/cn2svg.py
+++ b/cn2svg.py
@@ -113,7 +113,7 @@ class CadnanoDocument(object):
                     skip_dict[id_num].append((idx, insertion.length()))
                 else:
                     has_fwd, has_rev = part.hasStrandAtIdx(id_num, idx)
-                    fwd_col, rev_color = '#cccccc', '#cccccc'  # Defaults
+                    fwd_col, rev_col = '#cccccc', '#cccccc'  # Defaults
                     if has_fwd:
                         fwd_strand = part.getStrand(True, id_num, idx)
                         fwd_col = fwd_strand.getColor()


### PR DESCRIPTION
If `has_rev` evaluates to `False`, the value for `rev_col` is never set and appending 
```
 insertion_dict[id_num].append((idx, insertion.length(), fwd_col, rev_col))
``` 
on L123 will result in an `UnboundLocalError`.  

The value `rev_color` is never used in the code.  By renaming `rev_color` to `rev_col` (to keep things consistent with the name `fwd_col`), this error can be avoided:

```Traceback (most recent call last):
  File "/usr/local/cn2svg/cn2svg.py", line 631, in <module>
    main()
  File "/usr/local/cn2svg/cn2svg.py", line 618, in main
    cndoc = CadnanoDocument(design, sequence)
  File "/usr/local/cn2svg/cn2svg.py", line 49, in __init__
    self.insertions, self.skips = self.getInsertionsAndSkips()
  File "/usr/local/cn2svg/cn2svg.py", line 123, in getInsertionsAndSkips
    insertion_dict[id_num].append((idx, insertion.length(), fwd_col, rev_col))
UnboundLocalError: local variable 'rev_col' referenced before assignment
```